### PR TITLE
Fix `unenroll`.

### DIFF
--- a/server/src/models/RefundRequest.ts
+++ b/server/src/models/RefundRequest.ts
@@ -61,7 +61,7 @@ refundRequestSchema.methods.approve = async function () {
             return;
         }
         trainee.enrollments.splice(trainee.enrollments.indexOf(this.enrollmentId), 1);
-        // await Enrollment.findByIdAndDelete(this.enrollmentId);
+        await Enrollment.findByIdAndDelete(this.enrollmentId);
         trainee.credit(this.refundAmount);
         sendRefundRequestApprovalEmail(trainee.email, this.refundAmount);
     });


### PR DESCRIPTION
I agreed with @Abdulaziz-Hassan and @ShimaaBetah to model the enrollment using a composite key of `trainee id` and `course id` so both are unique 
Also, we created an `enrollment create service` that makes sure of the uniqueness so we have to clean old enrollment while unenroll, if not we will be stuck in an inconsistent state where he can't enroll or he's not enrolled since enrollment id is not in `trainee enrollment ids`.

Also `trainee enrollment ids` needs discussion, I am not sure if it's necessary. 